### PR TITLE
fix: broken link in AsyncStorage.js

### DIFF
--- a/lib/AsyncStorage.js
+++ b/lib/AsyncStorage.js
@@ -31,7 +31,7 @@ To fix this issue try these steps:
 
   • If you are using CocoaPods on iOS, run \`pod install\` in the \`ios\` directory and then rebuild and re-run the app.
 
-  • If this happens while testing with Jest, check out docs how to integrate AsyncStorage with it: https://github.com/react-native-community/react-native-async-storage/blob/master/docs/Jest-integration.md
+  • If this happens while testing with Jest, check out docs how to integrate AsyncStorage with it: https://github.com/react-native-community/async-storage/blob/LEGACY/docs/Jest-integration.md
 
 If none of these fix the issue, please open an issue on the Github repository: https://github.com/react-native-community/react-native-async-storage/issues 
 `);


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR!
Help us understand more of your work - you can explain what you did, post a link to an issue etc. Anything helps! -->

The previous link was 404ing since the docs were moved to a different dir.


Test Plan:
----------

<!-- Help us test your work (**REQUIRED**). If you changed the code, please provide us with instructions of how we can try it out ourselves, so we can confirm it's working. You can also post screenshots/gifts.  -->

Attempt to navigate to https://github.com/react-native-community/react-native-async-storage/blob/master/docs/Jest-integration.md in your browser. This should 404.

Attempt to navigate to https://github.com/react-native-community/async-storage/blob/LEGACY/docs/Jest-integration.md. This should work fine.